### PR TITLE
follow 307 redirects

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -114,6 +114,18 @@ module.exports = class Client extends EventEmitter {
       const contentEncoding = headers['content-encoding']
       const statusCode = res.statusCode
 
+      // "If HTTP 307, follow the redirect"
+      if (statusCode === 307) {
+        const redirectURL = new URL(headers['location']);
+        return this._makeRequest({
+          ...opts,
+          path: redirectURL.pathname,
+          hostname: redirectURL.hostname,
+          port: redirectURL.port,
+          protocol: redirectURL.protocol,
+        }, backoff, callback_);
+      }
+
       // "If HTTP 503, sleep 50-100ms and try again"
       if (statusCode === 503) {
         // TODO: use `http-errors` to attach status code to error


### PR DESCRIPTION
follow 307 redirects, transparently.
this is the expected behavior for a presto client, it's on the presto CLI and in other clients,
see official java client here: https://github.com/prestodb/presto/blob/ec2f4db19997a6a36fa06cca5705342b63f9c105/presto-client/src/main/java/com/facebook/presto/client/JsonResponse.java#L133-L139