### PR TITLE
follow 307 redirects

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -15,6 +15,7 @@ const concatArray = require('./concat-array')
 const PrestoError = require('./presto-error')
 const debug = require('debug')('lento')
 const VERSION = require('../package.json').version
+const URL = require('url').URL
 
 module.exports = class Client extends EventEmitter {
   constructor (opts) {
@@ -117,6 +118,19 @@ module.exports = class Client extends EventEmitter {
       const contentType = headers['content-type']
       const contentEncoding = headers['content-encoding']
       const statusCode = res.statusCode
+
+      // "If HTTP 307, follow the redirect"
+      if (statusCode === 307) {
+        const redirectURL = new URL(headers['location'])
+        return this._makeRequest(Object.assign(
+          Object.assign({}, opts),
+          {
+            path: redirectURL.pathname,
+            hostname: redirectURL.hostname,
+            port: redirectURL.port,
+            protocol: redirectURL.protocol
+          }), backoff, callback_)
+      }
 
       // "If HTTP 503, sleep 50-100ms and try again"
       if (statusCode === 503) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -121,6 +121,9 @@ module.exports = class Client extends EventEmitter {
 
       // "If HTTP 307, follow the redirect"
       if (statusCode === 307) {
+        if (!headers['location']) {
+          return callback(new Error('307 Redirect is missing Location header'))
+        }
         const redirectURL = new URL(headers['location'])
         if ((opts.protocol === 'http:') !== (redirectURL.protocol === 'http:')) {
           return callback(new Error('307 Redirect protocol switch is not allowed'))

--- a/lib/client.js
+++ b/lib/client.js
@@ -122,14 +122,16 @@ module.exports = class Client extends EventEmitter {
       // "If HTTP 307, follow the redirect"
       if (statusCode === 307) {
         const redirectURL = new URL(headers['location'])
-        return this._makeRequest(Object.assign(
-          Object.assign({}, opts),
-          {
-            path: redirectURL.pathname,
+        return this._makeRequest(
+          Object.assign({}, opts, {
+            protocol: redirectURL.protocol,
             hostname: redirectURL.hostname,
-            port: redirectURL.port,
-            protocol: redirectURL.protocol
-          }), backoff, callback_)
+            port: redirectURL.port ? parseInt(redirectURL.port, 10) : undefined,
+            path: redirectURL.pathname + redirectURL.search
+          }),
+          backoff,
+          callback_
+        )
       }
 
       // "If HTTP 503, sleep 50-100ms and try again"

--- a/lib/client.js
+++ b/lib/client.js
@@ -122,9 +122,11 @@ module.exports = class Client extends EventEmitter {
       // "If HTTP 307, follow the redirect"
       if (statusCode === 307) {
         const redirectURL = new URL(headers['location'])
+        if ((opts.protocol === 'http:') !== (redirectURL.protocol === 'http:')) {
+          return callback(new Error('307 Redirect protocol switch is not allowed'))
+        }
         return this._makeRequest(
           Object.assign({}, opts, {
-            protocol: redirectURL.protocol,
             hostname: redirectURL.hostname,
             port: redirectURL.port ? parseInt(redirectURL.port, 10) : undefined,
             path: redirectURL.pathname + redirectURL.search


### PR DESCRIPTION
follow 307 redirects, transparently.
this is the expected behavior for a presto client, it's on the presto CLI and in other clients,
see official java client here: https://github.com/prestodb/presto/blob/ec2f4db19997a6a36fa06cca5705342b63f9c105/presto-client/src/main/java/com/facebook/presto/client/JsonResponse.java#L133-L139