### PR TITLE
close open connections

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -121,6 +121,9 @@ module.exports = class Client extends EventEmitter {
 
       // Follow HTTP 307 redirects
       if (statusCode === 307) {
+        cancelRequest(req)
+        res.destroy()
+
         const location = headers.location
         let redirectUrl
 
@@ -151,6 +154,8 @@ module.exports = class Client extends EventEmitter {
 
       // "If HTTP 503, sleep 50-100ms and try again"
       if (statusCode === 503) {
+        cancelRequest(req)
+        res.destroy()
         // TODO: use `http-errors` to attach status code to error
         return retry(new Error('http 503'), 50, 100)
       }
@@ -398,4 +403,10 @@ function msOption (name, value) {
   if (n <= 0) throw new Error(name + ' must be > 0 milliseconds')
 
   return n
+}
+
+function cancelRequest (req) {
+  req.removeAllListeners()
+  req.on('error', function noop () {})
+  req.abort()
 }


### PR DESCRIPTION
I noticed after introducing the redirect follow behavior, the connection of the request obtaining the 307 wasn't getting closed (until a 60sec timeout, that might depend on your configuration).

I checked other libs following redirects, eg: https://github.com/follow-redirects/follow-redirects/blob/master/index.js#L284
and noticed the request connection must be explicitly aborted (and the response destroyed) if you're not consuming the response body.

I'm adding this for 503 errors too which have the same issue.